### PR TITLE
fix: package exports definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/cjs/duration-unit-format.cjs.js",
   "module": "dist/esm/duration-unit-format.esm.js",
   "exports": {
-    "import": "dist/esm/duration-unit-format.esm.js",
-    "default": "dist/cjs/duration-unit-format.cjs.js"
+    "import": "./dist/esm/duration-unit-format.esm.js",
+    "default": "./dist/cjs/duration-unit-format.cjs.js"
   },
   "scripts": {
     "compile": "rollup -c rollup.config.js",


### PR DESCRIPTION
Greetings 👋

Paths inside "package.exports" should be relative.

> All paths defined in the "exports" must be relative file URLs starting with ./.

Source: https://nodejs.org/api/packages.html